### PR TITLE
Removing volume mount to avoid reloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 evault-credentials.json
 webui/node_modules/
 tmp/
+
+.redis/
+.pgdata/
+.docker/

--- a/compose.yml
+++ b/compose.yml
@@ -4,8 +4,6 @@ services:
     container_name: evault-redis
     ports:
       - "6379:6379"
-    volumes:
-      - ./tmp/evault/redis:/data
     command: redis-server --appendonly yes
     environment:
       - REDIS_REPLICATION_MODE=master
@@ -15,8 +13,6 @@ services:
     container_name: evault-postgres
     ports:
       - "5432:5432"
-    volumes:
-      - ./tmp/evault/postgres_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=evault
       - POSTGRES_USER=${POSTGRES_USER}

--- a/compose.yml
+++ b/compose.yml
@@ -7,6 +7,8 @@ services:
     command: redis-server --appendonly yes
     environment:
       - REDIS_REPLICATION_MODE=master
+    volumes:
+      - ./.redis:/data
 
   postgres:
     image: postgres:17.5-alpine3.22
@@ -17,3 +19,6 @@ services:
       - POSTGRES_DB=evault
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    volumes:
+      - ./.pgdata:/var/lib/postgresql/data
+      - ./.docker/postgres/sql-init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
- Easy change for this, by removing a local volume mount, we don't trigger the hot refresh.
  - we would only lose data whenever we delete Docker, which is a rare occurance.