### PR TITLE
4 simplify auth routing for device type web

### DIFF
--- a/docs/authentications.md
+++ b/docs/authentications.md
@@ -1,0 +1,8 @@
+# OAuth Flow with GitHub
+
+## Web
+
++ User is redirected to `/api/auth?device_type=web`.
++ Server responds with 302 status code and a `Location` header containing the URL of the GitHub OAuth url.
++ GitHub provider redirects user back to `/auth/github` (front-end), where a `GET` request is issued to `/api/auth/token` with the required parameters.
++ Server sets a cookie with the session ID, mapping to the OAuth token granted to the user by GitHub in Redis.

--- a/src/server/auth_handlers.py
+++ b/src/server/auth_handlers.py
@@ -1,6 +1,7 @@
 import secrets, fastapi, urllib.parse as urlparse, json
 from fastapi.responses import PlainTextResponse, JSONResponse, RedirectResponse
 from fastapi import status
+from starlette.status import HTTP_200_OK
 from ..pkg.types import DeviceType, GithubAuthToken
 from .config import (
     app,
@@ -79,7 +80,7 @@ def auth_token(session_id: str, code: str, state: str, device_type: DeviceType):
         evault_access_token, gh_token, gh_user, EVAULT_SESSION_TOKEN_TTL
     )
 
-    response = fastapi.Response(status_code=200)
+    response = fastapi.Response(status_code=HTTP_200_OK)
     if device_type == "web":
         response.set_cookie(
             key="evault_access_token",

--- a/src/server/auth_handlers.py
+++ b/src/server/auth_handlers.py
@@ -1,7 +1,17 @@
 import secrets, fastapi, urllib.parse as urlparse, json
 from fastapi.responses import PlainTextResponse, JSONResponse
 from ..pkg.types import DeviceType, GithubAuthToken
-from .config import *
+from .config import (
+    app,
+    redis,
+    httpclient,
+    oauth_client,
+    EVAULT_WEB_URL,
+    EVAULT_TOKEN_POLL_TTL,
+    GITHUB_OAUTH_STATE_TTL,
+    EVAULT_SESSION_TOKEN_TTL,
+    EVAULT_TOKEN_POLL_MAX_ATTEMPT,
+)
 
 
 @app.get("/api/auth")

--- a/src/server/storage.py
+++ b/src/server/storage.py
@@ -1,13 +1,11 @@
 from typing import Literal, Optional, Tuple, Dict
 import redis as redispy
 from ..pkg.types import GithubAuthToken, GitHubUser
-from ..pkg.utils import env_or_default
 from fastapi import HTTPException
 import sqlalchemy as sql
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from .models import Repository
-from psycopg2.errors import UniqueViolation
 
 
 type SSLMode = Literal["require", "disable"]
@@ -27,7 +25,7 @@ class Database:
     ) -> None:
         conn_str = f"postgresql://{user}:{password}@{host}:{port}/{db}?sslmode={ssl}"
         self.engine = sql.create_engine(conn_str, echo=True)
-        print(f"Connected to database")
+        print("Connected to database")
 
     def get_repository(self, repo_id: int) -> Optional[Repository]:
         with Session(self.engine) as s:
@@ -52,7 +50,7 @@ class Redis(redispy.Redis):
     def __init__(self, host: str, port: int) -> None:
         super().__init__(host, port)
         self.ping()
-        print(f"Connected to redis")
+        print("Connected to redis")
 
     def create_user_session(
         self,

--- a/webui/src/routes/index.tsx
+++ b/webui/src/routes/index.tsx
@@ -19,15 +19,10 @@ function App() {
 
 function useHome() {
   async function signInRedirect() {
-    // get session_id
-    let r = await fetch(`/api/auth?device_type=web`);
-    const url = new URL(await r.text());
-    const searchParams = new URLSearchParams(url.search);
-    const sessionID = searchParams.get("session_id");
-
-    // get auth url and redirect
-    r = await fetch(`/api/auth/url?session_id=${sessionID}`);
-    window.location.href = await r.text();
+    // NOTE: can't do `fetch` here because the server is redirecting the request
+    // to the OAuth provider (GitHub), with `fetch`, browser blocks the redirect.
+    // this way the browser itself is making the `GET` request to be redirected.
+    window.location.href = "/api/auth?device_type=web";
   }
 
   return { signInRedirect };


### PR DESCRIPTION
This simplified the auth flow for web + clean up imports and refactored out some redis operation for authentication session management.

The direct comparison between this PR and the code in `main` is that the user on web has 1 less redirecting route to go through for auth
 
The flow is documented in [authentications.md](docs/authentications.md)

closes #4 