### PR TITLE
Adding default for email and sorting received repo by pushed

### DIFF
--- a/src/server/httpreqs.py
+++ b/src/server/httpreqs.py
@@ -35,7 +35,7 @@ class HttpClient(requests.Session):
         url = f"{self.base_url}/user/repos"
         headers = self._make_header(token_type, access_token)
 
-        r = self.get(url, headers=headers)
+        r = self.get(url, headers=headers, params={"sort": "pushed", "direction": "desc"})
         assert r.status_code == 200
 
         repos_data = r.json()

--- a/src/server/httpreqs.py
+++ b/src/server/httpreqs.py
@@ -55,6 +55,10 @@ class HttpClient(requests.Session):
 
         data = req.json()
 
+        # if the user has MFA, they do not have an email, set as N/A
+        if data["email"] is None:
+            data["email"] = "N/A"
+
         return dacite.from_dict(GitHubUser, data)
 
     def fetch_repository(

--- a/src/server/httpreqs.py
+++ b/src/server/httpreqs.py
@@ -35,7 +35,9 @@ class HttpClient(requests.Session):
         url = f"{self.base_url}/user/repos"
         headers = self._make_header(token_type, access_token)
 
-        r = self.get(url, headers=headers, params={"sort": "pushed", "direction": "desc"})
+        r = self.get(
+            url, headers=headers, params={"sort": "pushed", "direction": "desc"}
+        )
         assert r.status_code == 200
 
         repos_data = r.json()


### PR DESCRIPTION
Description of changes:
- My github has MFA so my email is not shared through OAuth, need to set default the email so my account would work.
- adding params to the repos query to reflect the GitHub repo screen's order.