### PR TITLE
Updating Session Expired HTTP code to 440

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -40,7 +40,7 @@ def get_access_token() -> Optional[str]:
         attempt += 1
 
         r = session.get(poll_url)
-        if r.status_code == 403:
+        if r.status_code == 403 or r.status_code == 440:
             break
 
         assert r.status_code == 200
@@ -72,9 +72,12 @@ def check_credentials(
             url = f"{SERVER}/api/auth/refresh?{urlencode(p)}"
             r = session.get(url)
 
-            if r.status_code == 403:
+            if r.status_code == 440:
                 print("\r\tSession expired.")
                 # os.remove(CREDENTIALS_PATH)
+                return None
+            elif r.status_code == 403:
+                print("\r\tInvalid token.")
                 return None
             elif r.status_code != 200:
                 raise Exception(f"Server error: {r.status_code}")

--- a/src/server/storage.py
+++ b/src/server/storage.py
@@ -85,7 +85,7 @@ class Redis(redispy.Redis):
         d = self.hgetall(name=key)
         d: Dict[bytes, bytes] = d
         if d == {}:
-            raise HTTPException(status_code=403, detail="Session expired.")
+            raise HTTPException(status_code=440, detail="Session expired.")
 
         gh_user = GitHubUser(
             id=int(d.get(b"user-id").decode()),
@@ -107,7 +107,7 @@ class Redis(redispy.Redis):
         key = self._make_session_key(evault_access_token)
         ctr = self.exists(key)
         if ctr == 0:
-            raise HTTPException(status_code=403, detail="Session expired.")
+            raise HTTPException(status_code=440, detail="Session expired.")
 
         self.expire(key, ttl)
 

--- a/webui/src/routes/dashboard/index.tsx
+++ b/webui/src/routes/dashboard/index.tsx
@@ -80,7 +80,7 @@ function useUser() {
   useEffect(() => {
     (async function () {
       const r = await fetch(`/api/dashboard/user`);
-      if (r.status === 403) nav({ to: "/" });
+      if (r.status === 440) nav({ to: "/" });
 
       const d = (await r.json()) as User;
       setUser(d);
@@ -112,7 +112,7 @@ function useRepository() {
   useEffect(() => {
     (async function () {
       const r = await fetch(`/api/dashboard/repositories`);
-      if (r.status === 403) nav({ to: "/" });
+      if (r.status === 440) nav({ to: "/" });
       const data = await r.json();
       setRepos(data);
     })();

--- a/webui/src/routes/dashboard/repository/$repoID.tsx
+++ b/webui/src/routes/dashboard/repository/$repoID.tsx
@@ -61,7 +61,7 @@ function Page() {
   return (
     <>
       <Breadcrumbs paths={breadcrumbs} />
-      {repoID.status === 403 ? (
+      {repoID.status === 440 ? (
         <>
           Session expired. Go back&nbsp;
           <Link to="/">Home.</Link>


### PR DESCRIPTION
I need to handle session expired and no access as 2 separate cases, but I noticed we're using 403 for both cases in our code for HTTP requests. I found this Microsoft used 440 Session Expired code here https://en.wikipedia.org/wiki/List_of_HTTP_status_codes, this PR is to switch to that.
- Updating all 403 Session Expired to 440.