### PR TITLE
21 UI for authgithub 2

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-router": "^1.120.20",
         "@tanstack/react-router-devtools": "^1.120.20",
         "@toolpad/core": "^0.16.0",
+        "motion": "^12.18.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2587,7 +2588,6 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3746,6 +3746,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4275,6 +4302,47 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.18.1.tgz",
+      "integrity": "sha512-w1ns2hWQ4COhOvnZf4rg4mW0Pl36mzcShpgt0fSfI6qJxKUbi3kHho/HSKeJFRoY0TO1m5/7C8lG1+Li0uC9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5079,6 +5147,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.19.4",

--- a/webui/package.json
+++ b/webui/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-router": "^1.120.20",
     "@tanstack/react-router-devtools": "^1.120.20",
     "@toolpad/core": "^0.16.0",
+    "motion": "^12.18.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/webui/src/hooks/auth.tsx
+++ b/webui/src/hooks/auth.tsx
@@ -49,7 +49,7 @@ export function useAuthGithub() {
       setError("Something went wrong.");
       console.error(queryError);
     }
-  }, [nav, status, error]);
+  }, [nav, status, error, params.error, queryError]);
 
   return { loading, status, error };
 }

--- a/webui/src/hooks/loadingText.ts
+++ b/webui/src/hooks/loadingText.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Changing loading text at `changeInterval` ms.
+ * Returns the index of the active loading text to be rendrered.
+ * */
+export function useLoadingText(changeInterval: number, loadingTexts: string[]) {
+  const lineCtr = loadingTexts.length;
+  const [index, setIndex] = useState(Math.floor(Math.random() * lineCtr));
+
+  useEffect(() => {
+    const intervalID = setInterval(() => {
+      const nextIndex = Math.floor(Math.random() * lineCtr);
+      setIndex(nextIndex);
+    }, changeInterval);
+    return () => clearInterval(intervalID);
+  }, [lineCtr, changeInterval]);
+
+  return { index };
+}

--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -1,10 +1,12 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { NotificationsProvider } from "@toolpad/core/useNotifications";
+import { queryClient } from "../utils/queryClient";
 
 export const Route = createRootRoute({
   component: () => (
-    <>
+    <QueryClientProvider client={queryClient}>
       <NotificationsProvider
         slotProps={{
           snackbar: {
@@ -21,6 +23,6 @@ export const Route = createRootRoute({
         <Outlet />
         <TanStackRouterDevtools />
       </NotificationsProvider>
-    </>
+    </QueryClientProvider>
   ),
 });

--- a/webui/src/routes/auth/github.tsx
+++ b/webui/src/routes/auth/github.tsx
@@ -1,23 +1,88 @@
+import { useEffect, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod/v4";
-import { paramParser } from "../../utils/zod/gitHubParams";
+import {
+  paramParser,
+  type GitHubOAuthSearchParamResult,
+} from "../../utils/zod/gitHubParams";
 import { useAuthGithub } from "../../hooks/auth";
+import { CircularProgress, Link, Stack, Typography } from "@mui/material";
+import { AnimatePresence, motion } from "motion/react";
+import { Link as RouterLink } from "@tanstack/react-router";
 
-type SearchParam = z.infer<typeof paramParser>;
+const TEXT_CHANGE_INTERVAL = 3000; // milliseconds
+const loadingTexts = [
+  "Authenticating with secure provider...",
+  "Verifying your identity...",
+  "Syncing your security credentials...",
+  "Confirming sharing privileges...",
+  "Checking vault sharing authorization...",
+];
 
 export const Route = createFileRoute("/auth/github")({
-  validateSearch: (s: Record<string, unknown>): SearchParam =>
-    paramParser.parse(s),
+  validateSearch: (s: Record<string, unknown>): GitHubOAuthSearchParamResult =>
+    paramParser.safeParse(s),
   component: RouteComponent,
 });
 
 function RouteComponent() {
   const f = useAuthGithub();
-  return f.loading ? (
-    <>Authenticating...</>
-  ) : f.error !== null ? (
-    <> {f.error}</>
+  const { index } = useLoadingText(TEXT_CHANGE_INTERVAL);
+
+  return f.status === "pending" || true ? (
+    <Stack
+      gap={4}
+      mt="30vh"
+      justifyItems="center"
+      alignItems="center"
+      mx="auto"
+    >
+      <Typography variant="h4" color="textPrimary">
+        Authenticating with GitHub
+      </Typography>
+
+      <Stack justifyItems="center" alignItems="center" gap={2}>
+        <CircularProgress />
+        <AnimatePresence mode="wait">
+          {loadingTexts.map((text, idx) => {
+            return index === idx ? (
+              <motion.div
+                key={`text-key-${idx}`}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 10 }}
+              >
+                <Typography variant="body1" color="textSecondary">
+                  {text}
+                </Typography>
+              </motion.div>
+            ) : null;
+          })}
+        </AnimatePresence>
+      </Stack>
+    </Stack>
+  ) : f.status === "error" ? (
+    <Stack mt="30vh" mx="auto" width="max-content" alignItems="center" gap={1}>
+      <Typography variant="h4">Authentication Failed</Typography>
+      <Link component={RouterLink} to="/">
+        Go back home.
+      </Link>
+    </Stack>
   ) : (
-    <>Authenticated, you can now close this window.</>
+    <></>
   );
+}
+
+function useLoadingText(changeInterval: number) {
+  const lineCtr = loadingTexts.length;
+  const [index, setIndex] = useState(Math.floor(Math.random() * lineCtr));
+
+  useEffect(() => {
+    const intervalID = setInterval(() => {
+      const nextIndex = Math.floor(Math.random() * lineCtr);
+      setIndex(nextIndex);
+    }, changeInterval);
+    return () => clearInterval(intervalID);
+  }, [lineCtr]);
+
+  return { index };
 }

--- a/webui/src/routes/auth/github.tsx
+++ b/webui/src/routes/auth/github.tsx
@@ -28,7 +28,7 @@ function RouteComponent() {
   const f = useAuthGithub();
   const { index } = useLoadingText(TEXT_CHANGE_INTERVAL);
 
-  return f.status === "pending" || true ? (
+  return f.status === "pending" ? (
     <Stack
       gap={4}
       mt="30vh"
@@ -82,7 +82,7 @@ function useLoadingText(changeInterval: number) {
       setIndex(nextIndex);
     }, changeInterval);
     return () => clearInterval(intervalID);
-  }, [lineCtr]);
+  }, [lineCtr, changeInterval]);
 
   return { index };
 }

--- a/webui/src/routes/auth/github.tsx
+++ b/webui/src/routes/auth/github.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
   paramParser,
@@ -8,6 +7,7 @@ import { useAuthGithub } from "../../hooks/auth";
 import { CircularProgress, Link, Stack, Typography } from "@mui/material";
 import { AnimatePresence, motion } from "motion/react";
 import { Link as RouterLink } from "@tanstack/react-router";
+import { useLoadingText } from "../../hooks/loadingText";
 
 const TEXT_CHANGE_INTERVAL = 3000; // milliseconds
 const loadingTexts = [
@@ -26,9 +26,32 @@ export const Route = createFileRoute("/auth/github")({
 
 function RouteComponent() {
   const f = useAuthGithub();
-  const { index } = useLoadingText(TEXT_CHANGE_INTERVAL);
 
-  return f.status === "pending" ? (
+  switch (f.status) {
+    case "pending":
+      return <LoadingState />;
+    case "error":
+      return <ErrorState />;
+    default: // case "success", should be redirected to `/dashboard`
+      return <></>;
+  }
+}
+
+function ErrorState() {
+  return (
+    <Stack mt="30vh" mx="auto" width="max-content" alignItems="center" gap={1}>
+      <Typography variant="h4">Authentication Failed</Typography>
+      <Link component={RouterLink} to="/">
+        Go back home.
+      </Link>
+    </Stack>
+  );
+}
+
+function LoadingState() {
+  const { index } = useLoadingText(TEXT_CHANGE_INTERVAL, loadingTexts);
+
+  return (
     <Stack
       gap={4}
       mt="30vh"
@@ -60,29 +83,5 @@ function RouteComponent() {
         </AnimatePresence>
       </Stack>
     </Stack>
-  ) : f.status === "error" ? (
-    <Stack mt="30vh" mx="auto" width="max-content" alignItems="center" gap={1}>
-      <Typography variant="h4">Authentication Failed</Typography>
-      <Link component={RouterLink} to="/">
-        Go back home.
-      </Link>
-    </Stack>
-  ) : (
-    <></>
   );
-}
-
-function useLoadingText(changeInterval: number) {
-  const lineCtr = loadingTexts.length;
-  const [index, setIndex] = useState(Math.floor(Math.random() * lineCtr));
-
-  useEffect(() => {
-    const intervalID = setInterval(() => {
-      const nextIndex = Math.floor(Math.random() * lineCtr);
-      setIndex(nextIndex);
-    }, changeInterval);
-    return () => clearInterval(intervalID);
-  }, [lineCtr, changeInterval]);
-
-  return { index };
 }

--- a/webui/src/routes/auth/github.tsx
+++ b/webui/src/routes/auth/github.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Navigate } from "@tanstack/react-router";
 import {
   paramParser,
   type GitHubOAuthSearchParamResult,
@@ -32,8 +32,8 @@ function RouteComponent() {
       return <LoadingState />;
     case "error":
       return <ErrorState />;
-    default: // case "success", should be redirected to `/dashboard`
-      return <></>;
+    default:
+      return <Navigate to="/dashboard" />;
   }
 }
 

--- a/webui/src/routes/dashboard.tsx
+++ b/webui/src/routes/dashboard.tsx
@@ -1,4 +1,3 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Outlet } from "@tanstack/react-router";
 
@@ -9,10 +8,5 @@ export const Route = createFileRoute("/dashboard")({
 function LayoutComponent() {
   // TODO: user needs to be logged in to access the dashboard if user is not logged in, redirect to the login page
 
-  const queryClient = new QueryClient();
-  return (
-    <QueryClientProvider client={queryClient}>
-      <Outlet />
-    </QueryClientProvider>
-  );
+  return <Outlet />;
 }

--- a/webui/src/services/auth.ts
+++ b/webui/src/services/auth.ts
@@ -1,4 +1,5 @@
 import type { User } from "../types/User";
+import type { GitHubOAuthSearchParams } from "../utils/zod/gitHubParams";
 import { fetchWithRedirect } from "./common";
 
 // Fetch the user's information from the API
@@ -8,6 +9,9 @@ export async function getUser(): Promise<User> {
 }
 
 // Exchange the GitHub authentication
-export async function getGitHubAuth(p: URLSearchParams) {
+export function getGitHubAuth(
+  params: GitHubOAuthSearchParams,
+): Promise<Response> {
+  const p = new URLSearchParams(params);
   return fetch(`/api/auth/token?${p.toString()}`);
 }

--- a/webui/src/utils/queryClient.ts
+++ b/webui/src/utils/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/webui/src/utils/zod/gitHubParams.ts
+++ b/webui/src/utils/zod/gitHubParams.ts
@@ -6,3 +6,8 @@ export const paramParser = z.object({
   code: z.string(),
   state: z.string(),
 });
+
+export type GitHubOAuthSearchParams = z.infer<typeof paramParser>;
+
+export type GitHubOAuthSearchParamResult =
+  z.ZodSafeParseResult<GitHubOAuthSearchParams>;


### PR DESCRIPTION
some front-end code for you to roast, picking up from #28

> - Added spinner and some dummy texts that gets faded in/out with `framermotion`
> - Added a global Tanstack's `queryClient` to `__root.tsx`
> 
> ![image](https://github.com/user-attachments/assets/41c9cd3d-93d7-4485-9fab-35895e8d9d55)

close #21 