### PR TITLE
Adding title to all React routes

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
   </head>
   <body>
     <div id="root"></div>

--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, HeadContent, Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { NotificationsProvider } from "@toolpad/core/useNotifications";
 import { queryClient } from "../utils/queryClient";
@@ -7,6 +7,8 @@ import { queryClient } from "../utils/queryClient";
 export const Route = createRootRoute({
   component: () => (
     <QueryClientProvider client={queryClient}>
+      <HeadContent />
+
       <NotificationsProvider
         slotProps={{
           snackbar: {

--- a/webui/src/routes/auth/github.tsx
+++ b/webui/src/routes/auth/github.tsx
@@ -19,6 +19,13 @@ const loadingTexts = [
 ];
 
 export const Route = createFileRoute("/auth/github")({
+  head: () => ({
+    meta: [
+      {
+        title: "Authenticating with GitHub | Evault",
+      },
+    ],
+  }),
   validateSearch: (s: Record<string, unknown>): GitHubOAuthSearchParamResult =>
     paramParser.safeParse(s),
   component: RouteComponent,

--- a/webui/src/routes/auth/index.tsx
+++ b/webui/src/routes/auth/index.tsx
@@ -1,6 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/auth/")({
+  head: () => ({
+    meta: [
+      {
+        title: "Authenticating | Evault",
+      },
+    ],
+  }),
   component: RouteComponent,
 });
 

--- a/webui/src/routes/dashboard/index.tsx
+++ b/webui/src/routes/dashboard/index.tsx
@@ -7,6 +7,13 @@ import { RepositoryList } from "../../components/dashboard/RepositoryList";
 import { LoaderWithText } from "../../components/common/LoaderWithText";
 
 export const Route = createFileRoute("/dashboard/")({
+  head: () => ({
+    meta: [
+      {
+        title: "Dashboard | Evault",
+      },
+    ],
+  }),
   component: RouteComponent,
 });
 
@@ -16,7 +23,7 @@ function RouteComponent() {
 
   return (
     <Box display="flex" flexDirection="column" gap={1}>
-      {user ? (
+      {user && repos ? (
         <>
           <Breadcrumbs paths={[{ display: "Dashboard", href: "/dashboard" }]} />
 

--- a/webui/src/routes/dashboard/repository/$repoID.tsx
+++ b/webui/src/routes/dashboard/repository/$repoID.tsx
@@ -15,9 +15,25 @@ type SearchParams = {
   repo: string;
 };
 
+// Since we are using the search params to validate repo owner, we need to create a title based on the search params
+// This can be updated to the global state to fetch the repository name once that is implemented
+const createTitleBasedOnSearchParams = (search: string) => {
+  const repo = new URLSearchParams(search).get("repo");
+  return repo ? `${repo} | Evault` : "Repository | Evault";
+};
+
 export const Route = createFileRoute("/dashboard/repository/$repoID")({
+  head: () => ({
+    meta: [
+      {
+        title: createTitleBasedOnSearchParams(window.location.search),
+      },
+    ],
+  }),
   component: RouteComponent,
   loader: async ({ params }) => {
+    // TODO: Instead of passing the search params to the loader, we should use a global state to store the repo name
+    // and then use that state to fetch the repository
     const search = new URLSearchParams(window.location.search);
     const repoFullName = search.get("repo") as string;
     const r = await getRepositoryByIDWithOwnerValidation(

--- a/webui/src/routes/index.tsx
+++ b/webui/src/routes/index.tsx
@@ -2,6 +2,13 @@ import { Box, Button, Container, CssBaseline, Typography } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
+  head: () => ({
+    meta: [
+      {
+        title: "Evault",
+      },
+    ],
+  }),
   component: App,
 });
 

--- a/webui/src/services/auth.ts
+++ b/webui/src/services/auth.ts
@@ -6,8 +6,7 @@ import type { GitHubOAuthSearchParams } from "../utils/zod/gitHubParams";
 export async function getUser(): Promise<User> {
   const r = await httpClient.get("/dashboard/user", {
     transformResponse: (data) => {
-      // TODO: adding zod type validation
-      return data;
+      return JSON.parse(data);
     },
   });
   return r.data;

--- a/webui/src/services/auth.ts
+++ b/webui/src/services/auth.ts
@@ -6,6 +6,7 @@ import type { GitHubOAuthSearchParams } from "../utils/zod/gitHubParams";
 export async function getUser(): Promise<User> {
   const r = await httpClient.get("/dashboard/user", {
     transformResponse: (data) => {
+      // TODO: add zod type validation
       return JSON.parse(data);
     },
   });


### PR DESCRIPTION
Description of changes:
- Adding document head from https://tanstack.com/router/v1/docs/framework/react/guide/document-head-management to all routes, also adding dynamic title for repo-specific pages
- Had to add JSON.parse due to the data from user became a string somehow? This will be replaced when we add validations.